### PR TITLE
Add error types

### DIFF
--- a/rticonnextdds_connector.go
+++ b/rticonnextdds_connector.go
@@ -24,6 +24,16 @@ import (
 )
 
 /********
+* Errors *
+*********/
+
+// ErrNoData is returned when there is no data available in the DDS layer
+var ErrNoData = errors.New("DDS Exception: No Data")
+
+// ErrTimeout is returned when there is a timeout in the DDS layer
+var ErrTimeout = errors.New("DDS Exception: Timeout")
+
+/********
 * Types *
 *********/
 
@@ -193,9 +203,9 @@ func checkRetcode(retcode int) error {
 	switch retcode {
 	case DDSRetCodeOK:
 	case DDSRetCodeNoData:
-		return errors.New("DDS Exceptrion: No Data")
+		return ErrNoData
 	case DDSRetCodeTimeout:
-		return errors.New("DDS Exception: Timeout")
+		return ErrTimeout
 	default:
 		return errors.New("DDS Exception: " + C.GoString((*C.char)(C.RTI_Connector_get_last_error_message)))
 	}


### PR DESCRIPTION
### Changes

* Export error types for `No Data` and `Timeout` return codes

### Reason 

In calling code it is often needed to handle timeouts and no-data errors differently to other core errors as these errors can occur as part of a normal connection process.  

Testing the error string in the calling code relies on internal knowledge of the library and could be broken by a future update.  Exporting the error types allows the error text to change in the future.  It also makes testing for the error simple, for example:

```go
import (
	rti "github.com/rticommunity/rticonnextdds-connector-go"
)

...

if errors.Is(err, rti.ErrNoData) {
  // Handle no data
}
```

This change also corrects a typo in one error string "Exceptrion" which could make it a breaking change if anyone currently relies on string matching.

This change was authored by my colleague @mwak2 who is no longer with the company. 